### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Flask-based web application for analyzing lottery draw patterns and statistics
 2. Install the required dependencies:
 
 ```bash
-pip install flask pymysql
+pip install -r requirements.txt
 ```
 
 3. Copy Bootstrap files:


### PR DESCRIPTION
## Summary
- fix install command to use `requirements.txt`
- ensure README ends with a newline

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684864ad0554832c841a141abcd68e6e